### PR TITLE
Reusable Geofences/Circles

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,8 @@ const apiRoutes = require('./routes/api.js');
 const uiRoutes = require('./routes/ui.js');
 const routes = new DeviceController();
 
+// TODO: Fix caching of `default.js`
+
 (async () => {
     // View engine
     app.set('view engine', 'mustache');

--- a/src/models/geofence.js
+++ b/src/models/geofence.js
@@ -1,0 +1,174 @@
+'use strict';
+
+const config = require('../config.json');
+const MySQLConnector = require('../services/mysql.js');
+const db = new MySQLConnector(config.db);
+
+const GeofenceType = {
+    Circle: 'circle',
+    Geofence: 'geofence'
+};
+
+class Geofence {
+    
+    constructor(name, type, data) {
+        this.name = name;
+        this.type = type;
+        this.data = data;
+    }
+
+    /**
+     * Load all geofences/circle routes.
+     */
+    static async getAll() {
+        let sql = `
+        SELECT name, type, data
+        FROM geofence
+        `;
+        let results = await db.query(sql)
+            .then(x => x)
+            .catch(err => {
+                console.error('[Geofence] Error:', err);
+                return null;
+            });
+        let geofences = [];
+        if (results) {
+            for (let i = 0; i < results.length; i++) {
+                let result = results[i];
+                geofences.push(new Geofence(
+                    result.name,
+                    result.type,
+                    JSON.parse(result.data)
+                ));
+            }
+        }
+        return geofences;
+    }
+    
+    /**
+     * Get geofence by name.
+     */
+    static async getByName(name) {
+        let sql = `
+        SELECT name, type, data
+        FROM geofence
+        WHERE name = ?
+        `;
+        let args = [name];
+        let results = await db.query(sql, args)
+            .then(x => x)
+            .catch(err => {
+                console.error('[Geofence] Error:', err);
+                return null;
+            });
+        if (results && results.length > 0) {
+            let result = results[0];
+            return new Geofence(
+                result.name,
+                result.type,
+                JSON.parse(result.data)
+            );
+        }
+        return null;
+    }
+
+    static async deleteByName(name) {
+        let sql = `
+        DELETE FROM geofence
+        WHERE name = ?
+        `;
+        let args = [name];
+        try {
+            let results = await db.query(sql, args);
+            console.log('[Geofence] DeleteByName:', results);
+        } catch (err) {
+            console.error('[Geofence] Error:', err);
+        }
+    }
+
+    async create() {
+        let sql = `
+        INSERT INTO geofence (name, type, data) VALUES (?, ?, ?)
+        ON DUPLICATE KEY UPDATE
+            type=VALUES(type),
+            data=VALUES(data)
+        `;
+        let args = [this.name, this.type, JSON.stringify(this.data || {})];
+        try {
+            let results = await db.query(sql, args);
+            console.log('[Geofence] Save:', results);
+        } catch (err) {
+            console.error('[Geofence] Error:', err);
+        }
+    }
+
+    async save(oldName) {
+        let sql = `
+        UPDATE geofence SET name = ?, type = ?, data = ?
+        WHERE name = ?
+        `;
+        let args = [this.name, this.type, JSON.stringify(this.data || {}), oldName];
+        try {
+            let results = await db.query(sql, args);
+            console.log('[Geofence] Save:', results);
+        } catch (err) {
+            console.error('[Geofence] Error:', err);
+        }
+    }
+
+    static areaToGeofences(area) {
+        let coordArray = [];
+        let areaRows = area.split('\n');
+        let currentIndex = 0;
+        for (let i = 0; i < areaRows.length; i++) {
+            const areaRow = areaRows[i];
+            let rowSplit = areaRow.split(',');
+            if (rowSplit.length === 2) {
+                let lat = parseFloat(rowSplit[0].trim());
+                let lon = parseFloat(rowSplit[1].trim());
+                if (lat && lon) {
+                    while (coordArray.length !== currentIndex + 1) {
+                        coordArray.push([]);
+                    }
+                    coordArray[currentIndex].push({
+                        lat: lat,
+                        lon: lon
+                    });
+                }
+            } else if (areaRow.includes('[') && areaRow.includes(']') &&
+                       coordArray.length > currentIndex && coordArray[currentIndex].length !== 0) {
+                currentIndex++;
+            }
+        }
+        return coordArray;        
+    }
+    
+    static areaToCirclePoints(area) {
+        let coords = [];
+        let areaRows = area.split('\n');
+        for (let i = 0; i < areaRows.length; i++) {
+            const areaRow = areaRows[i];
+            let rowSplit = areaRow.split(',');
+            if (rowSplit.length === 2) {
+                let lat = parseFloat(rowSplit[0].trim());
+                let lon = parseFloat(rowSplit[1].trim());
+                if (lat && lon) {
+                    coords.push({ lat: lat, lon: lon });
+                }
+            }
+        }
+        return coords;        
+    }
+
+    static fromString(type) {
+        switch (type) {
+            case 'circle':
+                return 'Circle';
+            case 'geofence':
+                return 'Geofence';
+        }
+        return null;
+    }
+}
+
+module.exports = { GeofenceType, Geofence };

--- a/src/views/geofence-add.mustache
+++ b/src/views/geofence-add.mustache
@@ -1,0 +1,35 @@
+{{> navbar}}
+
+<body class="{{body_class}}">
+    <br>
+    <div class="alert alert-danger w-75 {{^show_error}}d-none{{/show_error}}" style="float: none; margin: 0 auto;">
+        <strong>Error!</strong> {{error}}</a>
+    </div>
+    {{#show_error}}<br>{{/show_error}}
+
+    <h1 align="center">Add a new Geofence to {{title}}!</h1>
+    <br>
+    <div class="w-75" style="float: none; margin: 0 auto;">
+        <form action="" method="post">
+            <div class="form-group">
+                Name
+                <input type="text" class="form-control" name="name" value="{{name}}" required minlength="1" maxlength="30">
+            </div>
+            <div class="form-group">
+                Geofence Type
+                <select class="form-control type-select" name="type" required>
+                    <option value="" {{#nothing_selected}}selected{{/nothing_selected}} disabled hidden>Choose Geofence Type</option>
+                    <option value="circle" {{#circle_selected}}selected{{/circle_selected}}>Circle</option>
+                    <option value="geofence" {{#geofence_selected}}selected{{/geofence_selected}}>Geofence</option>
+                </select>
+            </div>
+            <div class="form-group">
+                Scan Area
+                <textarea class="form-control" rows="5" name="area" required>{{{area}}}</textarea>
+            </div>
+            <input type="hidden" name="_csrf" value="{{csrf}}">
+            <button type="submit" class="btn btn-primary">Create</button>
+        </form>
+    </div>
+    <br>
+</body>

--- a/src/views/geofence-edit.mustache
+++ b/src/views/geofence-edit.mustache
@@ -1,0 +1,41 @@
+{{> navbar}}
+
+<body class="{{body_class}}">
+    <br>
+    <div class="alert alert-danger w-75 {{^show_error}}d-none{{/show_error}}" style="float: none; margin: 0 auto;">
+        <strong>Error!</strong> {{error}}</a>
+    </div>
+    {{#show_error}}<br>{{/show_error}}
+
+    <h1 align="center">Edit Geofence "{{old_name}}"!</h1>
+    <br>
+    <div class="w-75" style="float: none; margin: 0 auto;">
+        <form action="" method="post">
+            <div class="form-group">
+                Name
+                <input type="text" class="form-control" name="name" value="{{name}}" required minlength="1" maxlength="30">
+            </div>
+            <div class="form-group">
+                Geofence Type
+                <select class="form-control type-select" name="type" required>
+                    <option value="" {{#nothing_selected}}selected{{/nothing_selected}} disabled hidden>Choose Geofence Type</option>
+                    <option value="circle" {{#circle_selected}}selected{{/circle_selected}}>Circle</option>
+                    <option value="geofence" {{#geofence_selected}}selected{{/geofence_selected}}>Geofence</option>
+                </select>
+            </div>
+            <div class="form-group">
+                Scan Area
+                <textarea class="form-control" rows="5" name="area" required>{{{area}}}</textarea>
+            </div>
+            <input type="hidden" name="_csrf" value="{{csrf}}">
+            <button type="submit" class="btn btn-primary">Update</button>
+        </form>
+        <br>
+        <form action="" method="post" onsubmit="return confirm('Are you sure that you want to delete the geofence {{old_name}}?');">
+            <input type="hidden" name="_csrf" value="{{csrf}}">
+            <input type="hidden" name="delete" value="true">
+            <button type="submit" class="btn btn-danger">Delete</button>
+        </form>
+    </div>
+    <br>
+</body>

--- a/src/views/geofences.mustache
+++ b/src/views/geofences.mustache
@@ -1,0 +1,55 @@
+{{> navbar}}
+
+<script>
+	$(document).ready(function() {
+		const table = $('#table').DataTable( {
+			"ajax": {
+				"url": "/api/geofences",
+				"dataSrc": "data.geofences",
+                "type": "POST",
+			},
+			"paging":   true,
+			"lengthMenu": [[25, 50, 100, -1], [25, 50, 100, "All"]],
+			"columns": [
+				{ "data": "name" },
+                { "data": "type" },
+				{ "data": "buttons" }
+			],
+			"info":     false,
+			"order": [[ 0, "asc" ]],
+			"search.caseInsensitive": true,
+			"columnDefs": [ {
+				"targets": [2],
+				"orderable": false
+			}],
+            "responsive": true
+        });
+        $('#table').on('draw.dt', function () {
+            setTimeout(function () {
+                table.ajax.reload(null, false);
+            }, 15 * 1000);
+        });
+	} );
+</script>
+
+<body class="{{body_class}}">
+    <br>
+    <h1 align="center">Configure {{title}}'s Geofences!</h1>
+    <br>
+    <div style="width:90%; margin-left:calc(5%);">
+        <a href="/geofence/add" role="button" style="float: right;" class="btn btn-success">Add New Geofence</a>
+        <br><br>
+        <table id="table" class="table {{table_class}} table-striped table-bordered dt-responsive nowrap" style="position: center; width:100%">
+            <thead>
+            <tr>
+                <th>Name</th>
+                <th>Type</th>
+                <th width="5%"></th>
+            </tr>
+            </thead>
+            <tbody>
+            </tbody>
+        </table>
+    </div>
+    <br>
+</body>

--- a/src/views/index.mustache
+++ b/src/views/index.mustache
@@ -11,7 +11,7 @@
         <div class="card-body">
             <div class="container">
                 <div class="row">
-                    <div class="col-lg-3">
+                    <div class="col-lg-4">
                         <div class="list-group">
                             <a class="list-group-item {{body_class}}" href="/devices">
                                 <h3 class="pull-right"><i class="fa fa-fw fa-mobile-alt" aria-hidden="true"></i></h3>
@@ -20,7 +20,7 @@
                             </a>
                         </div>
                     </div>
-                    <div class="col-lg-3">
+                    <div class="col-lg-4">
                         <div class="list-group">
                             <a class="list-group-item {{body_class}}" href="/instances">
                                 <h3 class="pull-right"><i class="fa fa-fw fa-tasks" aria-hidden="true"></i></h3>
@@ -29,7 +29,16 @@
                             </a>
                         </div>
                     </div>
-                    <div class="col-lg-3">
+                    <div class="col-lg-4">
+                        <div class="list-group">
+                            <a class="list-group-item {{body_class}}" href="/geofences">
+                                <h3 class="pull-right"><i class="fa fa-fw fa-map-marker-alt" aria-hidden="true"></i></h3>
+                                <h4 class="list-group-item-heading text-light">{{geofences_count}}</h4>
+                                <p class="list-group-item-text text-light">Geofences</p>
+                            </a>
+                        </div>
+                    </div>
+                    <div class="col-lg-4">
                         <div class="list-group">
                             <a class="list-group-item {{body_class}}" href="/assignments">
                                 <h3 class="pull-right"><i class="fa fa-fw fa-cog" aria-hidden="true"></i></h3>
@@ -38,7 +47,7 @@
                             </a>
                         </div>
                     </div>
-                    <div class="col-lg-3">
+                    <div class="col-lg-4">
                         <div class="list-group">
                             <a class="list-group-item {{body_class}}" href="/accounts">
                                 <h3 class="pull-right"><i class="fa fa-fw fa-user" aria-hidden="true"></i></h3>

--- a/src/views/instance-add.mustache
+++ b/src/views/instance-add.mustache
@@ -1,6 +1,7 @@
 {{> navbar}}
 
 <script>
+    // TODO: Hide geofence element until instance type is selected
     $(document).ready(function() {
         $('.type-select').change(function() {
             switch ($(this).val()) {
@@ -8,16 +9,22 @@
                     $('.pokemon_ids_text').removeClass('d-none');
                     $('.iv_queue_limit_text').removeClass('d-none');
                     $('.spin_limit_text').addClass('d-none');
+                    $('.circle').addClass('d-none');
+                    $('.geofence').removeClass('d-none');
                     break;
                 case 'auto_quest':
                     $('.pokemon_ids_text').addClass('d-none');
                     $('.iv_queue_limit_text').addClass('d-none');
                     $('.spin_limit_text').removeClass('d-none');
+                    $('.circle').addClass('d-none');
+                    $('.geofence').removeClass('d-none');
                     break;
                 default:
                     $('.pokemon_ids_text').addClass('d-none');
                     $('.iv_queue_limit_text').addClass('d-none');
                     $('.spin_limit_text').addClass('d-none');
+                    $('.circle').removeClass('d-none');
+                    $('.geofence').addClass('d-none');
                     break;
             }
         });
@@ -61,8 +68,13 @@
                 <input type="number" class="form-control" name="max_level" value="{{max_level}}" step=1 min="0" max="40" required>
             </div>
             <div class="form-group">
-                Scan Area
-                <textarea class="form-control" rows="5" name="area" required>{{{area}}}</textarea>
+                Select Geofence
+                <select class="form-control" name="geofence" required>
+                    <option value="" {{#nothing_selected}}selected{{/nothing_selected}} disabled hidden>Choose Geofence</option>
+                    {{#geofences}}
+                        <option value="{{name}}" class="{{type}}" {{#selected}}selected{{/selected}}>{{name}}</option>
+                    {{/geofences}}
+                </select>
             </div>
             <div class="form-group pokemon_ids_text {{^pokemon_iv_selected}}d-none{{/pokemon_iv_selected}}">
                 Pokemon IDs (first = highest priority)

--- a/src/views/instance-edit.mustache
+++ b/src/views/instance-edit.mustache
@@ -2,6 +2,15 @@
 
 <script>
     $(document).ready(function() {
+        if ($('.type-select').val() === 'pokemon_iv' ||
+            $('.type-select').val() === 'auto_quest') {
+            $('.circle').addClass('d-none');
+            $('.geofence').removeClass('d-none');
+        } else {
+            $('.circle').removeClass('d-none');
+            $('.geofence').addClass('d-none');
+        }
+        
         $('.type-select').change(function() {
             switch ($(this).val()) {
                 case 'pokemon_iv':
@@ -10,6 +19,8 @@
                     $('.iv_queue_limit_text').removeClass('d-none');
                     $('.clear_quests_form').addClass('d-none');
                     $('.spin_limit_text').addClass('d-none');
+                    $('.circle').addClass('d-none');
+                    $('.geofence').removeClass('d-none');
                     break;
                 case 'auto_quest':
                     $('.pokemon_ids_text').addClass('d-none');
@@ -17,6 +28,8 @@
                     $('.iv_queue_limit_text').addClass('d-none');
                     $('.clear_quests_form').removeClass('d-none');
                     $('.spin_limit_text').removeClass('d-none');
+                    $('.circle').addClass('d-none');
+                    $('.geofence').removeClass('d-none');
                     break;
                 default:
                     $('.pokemon_ids_text').addClass('d-none');
@@ -24,6 +37,8 @@
                     $('.iv_queue_limit_text').addClass('d-none');
                     $('.clear_quests_form').addClass('d-none');
                     $('.spin_limit_text').addClass('d-none');
+                    $('.circle').removeClass('d-none');
+                    $('.geofence').addClass('d-none');
                     break;
             }
         });
@@ -67,8 +82,13 @@
                 <input type="number" class="form-control" name="max_level" value="{{max_level}}" step=1 min="0" max="40" required>
             </div>
             <div class="form-group">
-                Scan Area
-                <textarea class="form-control" rows="5" name="area" required>{{{area}}}</textarea>
+                Select Geofence
+                <select class="form-control" name="geofence" required>
+                    <option value="" {{#nothing_selected}}selected{{/nothing_selected}} disabled hidden>Choose Geofence</option>
+                    {{#geofences}}
+                        <option value="{{name}}" class="{{type}}" {{#selected}}selected{{/selected}}>{{name}}</option>
+                    {{/geofences}}
+                </select>
             </div>
             <div class="form-group pokemon_ids_text {{^pokemon_iv_selected}}d-none{{/pokemon_iv_selected}}">
                 Pokemon IDs (first = highest priority)

--- a/src/views/instances.mustache
+++ b/src/views/instances.mustache
@@ -35,6 +35,7 @@
                 { "data": "name" },
                 { "data": "type" },
                 { "data": "status" },
+                { "data": "geofence" },
                 { "data": "area_count" },
                 { "data": "count" },
                 { "data": "buttons" }
@@ -43,7 +44,7 @@
             "order": [[ 0, "asc" ]],
             "search.caseInsensitive": true,
             "columnDefs": [ {
-                "targets": [4],
+                "targets": [5],
                 "orderable": false
             }],
             "responsive": true
@@ -69,6 +70,7 @@
                 <th class="all">Name</th>
                 <th class="min-desktop">Type</th>
                 <th class="all">Status</th>
+                <th class="all">Geofence</th>
                 <th class="min-desktop">No. Circles/Geofences</th>
                 <th class="min-desktop">Devices</th>
                 <th class="all" width="5%"></th>

--- a/src/views/navbar.mustache
+++ b/src/views/navbar.mustache
@@ -20,6 +20,9 @@
                 <a class="nav-link" href="/instances"><i class="fa fa-fw fa-tasks" aria-hidden="true"></i>&nbsp;Instances</a>
             </li>
             <li class="nav-item">
+                <a class="nav-link" href="/geofences"><i class="fa fa-fw fa-map-marker-alt" aria-hidden="true"></i>&nbsp;Geofences</a>
+            </li>
+            <li class="nav-item">
                 <a class="nav-link" href="/assignments"><i class="fa fa-fw fa-cog" aria-hidden="true"></i>&nbsp;Assignments</a>
             </li>
             <li class="nav-item">


### PR DESCRIPTION
Allows for reusable geofences and circle points.

* Retains support for instances that aren't using assigned geofences yet. (Uses old saved geofence data from instance until you update it)
* Supports multiple geofences such as before.
* Checks if geofence type matches instance type. i.e. Geofence type is geofence and instance type is IV or Quests.

Add new geofence page:
![image](https://user-images.githubusercontent.com/1327440/93223880-61824780-f725-11ea-9e0b-fea3125f1f82.png)

Geofences page:
![image](https://user-images.githubusercontent.com/1327440/93224129-a60de300-f725-11ea-97dd-b3ac513e1638.png)

Add new instance page:
![image](https://user-images.githubusercontent.com/1327440/93224194-b6be5900-f725-11ea-93f3-bf3ae51fdbea.png)

Instances page:
![image](https://user-images.githubusercontent.com/1327440/93224101-9e4e3e80-f725-11ea-942f-c5224dcb0aff.png)

TODO:
- Hide geofence selection on new instance page until instance type is selected
- Move geofence/circle count from instances page to geofences page