### PR TITLE
Level Split for Add Accounts

### DIFF
--- a/src/routes/ui.js
+++ b/src/routes/ui.js
@@ -365,7 +365,7 @@ router.use('/clearquests', async (req, res) => {
 
 
 const addAccounts = (req, res) => {
-    let level = parseInt(req.body.level || 0);
+    let defaultLevel = parseInt(req.body.level || 0);
     let accounts = req.body.accounts;
     if (!accounts) {
         data['show_error'] = true;
@@ -379,16 +379,17 @@ const addAccounts = (req, res) => {
 
     let data = req.body;
     data['accounts'] = accounts;
-    data['level'] = level;
+    data['level'] = defaultLevel;
 
     let accs = [];
     let accountRows = accounts.split('\n');
     for (let i = 0; i < accountRows.length; i++) {
         let row = accountRows[i];
         let split = row.split(',');
-        if (split.length === 2) {
+        if (split.length === 2 || split.length === 3) {
             let username = split[0].trim();
             let password = split[1].trim();
+            let level = split.length === 3 ? split[2].trim() : defaultLevel;
             accs.push(new Account(username, password, null, null, null, level, null, null, null, 0, 0, null, null, null, null, null, null, null));
         }
     }

--- a/src/views/accounts-add.mustache
+++ b/src/views/accounts-add.mustache
@@ -20,7 +20,7 @@
                 <textarea class="form-control" rows="5" name="accounts" required>{{{accounts}}}</textarea>
                 <br>
                 <div class="alert alert-warning" role="alert">
-                    Format: username,password
+                    Set the default level for the accounts in the Account Level field if you only have usernames and passwords. Otherwise use the following format: username,password,level
                     <br>
                     Acceptable delimiters: <b>,</b> (comma) <b>:</b> (colon) or <b>;</b> (semicolon)
                     <br>


### PR DESCRIPTION
- Adds optional ability to insert individual levels when adding accounts. Defaults to whatever is put in the "Account Level" field if only usernames & passwords are inserted.